### PR TITLE
feat(metadata): 新增查看表结构DDL功能

### DIFF
--- a/src-tauri/src/commands/metadata.rs
+++ b/src-tauri/src/commands/metadata.rs
@@ -47,3 +47,23 @@ pub async fn get_table_structure(
     let driver = get_driver(&form)?;
     driver.get_table_structure(schema, table).await
 }
+
+#[tauri::command]
+pub async fn get_table_ddl(
+    state: State<'_, AppState>,
+    id: i64,
+    database: Option<String>,
+    schema: String,
+    table: String,
+) -> Result<String, String> {
+    let local_db = state.local_db.lock().await;
+    let db = local_db.as_ref().ok_or("Local DB not initialized")?;
+
+    let mut form = db.get_connection_form_by_id(id).await?;
+    if let Some(db_name) = database {
+        form.database = Some(db_name);
+    }
+
+    let driver = get_driver(&form)?;
+    driver.get_table_ddl(schema, table).await
+}

--- a/src-tauri/src/db/drivers/mod.rs
+++ b/src-tauri/src/db/drivers/mod.rs
@@ -12,6 +12,7 @@ pub trait DatabaseDriver: Send + Sync {
     async fn list_databases(&self) -> Result<Vec<String>, String>;
     async fn list_tables(&self, schema: Option<String>) -> Result<Vec<TableInfo>, String>;
     async fn get_table_structure(&self, schema: String, table: String) -> Result<TableStructure, String>;
+    async fn get_table_ddl(&self, schema: String, table: String) -> Result<String, String>;
     async fn get_table_data(&self, schema: String, table: String, page: i64, limit: i64) -> Result<TableDataResponse, String>;
     async fn execute_query(&self, sql: String) -> Result<QueryResult, String>;
 }

--- a/src-tauri/src/db/drivers/mysql.rs
+++ b/src-tauri/src/db/drivers/mysql.rs
@@ -142,6 +142,25 @@ impl DatabaseDriver for MysqlDriver {
         Ok(TableStructure { columns })
     }
 
+    async fn get_table_ddl(
+        &self,
+        schema: String,
+        table: String,
+    ) -> Result<String, String> {
+        let pool = self.get_pool().await?;
+        let qualified = if schema.is_empty() {
+            format!("`{}`", table)
+        } else {
+            format!("`{}`.`{}`", schema, table)
+        };
+        let query = format!("SHOW CREATE TABLE {}", qualified);
+        let row: (String, String) = sqlx::query_as(&query)
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| format!("[QUERY_ERROR] {e}"))?;
+        Ok(row.1)
+    }
+
     async fn get_table_data(
         &self,
         schema: String,

--- a/src-tauri/src/db/drivers/postgres.rs
+++ b/src-tauri/src/db/drivers/postgres.rs
@@ -135,6 +135,41 @@ impl DatabaseDriver for PostgresDriver {
         Ok(TableStructure { columns })
     }
 
+    async fn get_table_ddl(
+        &self,
+        schema: String,
+        table: String,
+    ) -> Result<String, String> {
+        let pool = self.get_pool().await?;
+        let query = r#"
+            SELECT
+                'CREATE TABLE ' || quote_ident(n.nspname) || '.' || quote_ident(c.relname) || ' (' || E'\n' ||
+                array_to_string(array_agg(
+                    '    ' || quote_ident(a.attname) || ' ' ||
+                    format_type(a.atttypid, a.atttypmod) ||
+                    CASE WHEN a.attnotnull THEN ' NOT NULL' ELSE '' END ||
+                    CASE WHEN a.atthasdef THEN ' DEFAULT ' || pg_get_expr(d.adbin, d.adrelid) ELSE '' END
+                ), E',\n') || E'\n' ||
+                ');'
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            JOIN pg_attribute a ON a.attrelid = c.oid
+            LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+            WHERE c.relkind = 'r' AND a.attnum > 0 AND NOT a.attisdropped
+            AND n.nspname = $1 AND c.relname = $2
+            GROUP BY n.nspname, c.relname;
+        "#;
+
+        let row: (String,) = sqlx::query_as(query)
+            .bind(&schema)
+            .bind(&table)
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| format!("[QUERY_ERROR] {e}"))?;
+
+        Ok(row.0)
+    }
+
     async fn get_table_data(
         &self,
         schema: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -39,6 +39,7 @@ pub fn run() {
             commands::connection::delete_connection,
             commands::metadata::list_tables,
             commands::metadata::get_table_structure,
+            commands::metadata::get_table_ddl,
             commands::query::execute_query,
             commands::query::get_table_data,
             commands::query::cancel_query,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -378,6 +378,19 @@ export default function App() {
                           pageSize={tab.pageSize}
                           executionTimeMs={tab.executionTimeMs}
                           onPageChange={(p) => handlePageChange(tab.id, p)}
+                          tableContext={
+                            tab.connectionId && tab.database && tab.tableName
+                              ? {
+                                  connectionId: tab.connectionId,
+                                  database: tab.database,
+                                  schema:
+                                    tab.driver === "mysql"
+                                      ? tab.database
+                                      : "public",
+                                  table: tab.tableName,
+                                }
+                              : undefined
+                          }
                         />
                       )}
                     </TabsContent>

--- a/src/components/business/DataGrid/TableView.tsx
+++ b/src/components/business/DataGrid/TableView.tsx
@@ -8,6 +8,7 @@ import {
   Copy,
   Table as TableIcon,
   Files,
+  FileCode,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -30,6 +31,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+import Editor from "@monaco-editor/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { api } from "@/services/api";
 
 interface TableViewProps {
   data?: any[];
@@ -40,6 +49,12 @@ interface TableViewProps {
   pageSize?: number;
   executionTimeMs?: number;
   onPageChange?: (page: number) => void;
+  tableContext?: {
+    connectionId: number;
+    database: string;
+    schema: string;
+    table: string;
+  };
 }
 
 export function TableView({
@@ -51,9 +66,35 @@ export function TableView({
   pageSize = 50,
   executionTimeMs = 0,
   onPageChange,
+  tableContext,
 }: TableViewProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+  const [isDDLModalOpen, setIsDDLModalOpen] = useState(false);
+  const [ddlContent, setDDLContent] = useState("");
+  const [isLoadingDDL, setIsLoadingDDL] = useState(false);
+
+  const handleShowDDL = async () => {
+    if (!tableContext) return;
+    setIsDDLModalOpen(true);
+    if (!ddlContent) {
+      setIsLoadingDDL(true);
+      try {
+        const ddl = await api.metadata.getTableDDL(
+          tableContext.connectionId,
+          tableContext.database,
+          tableContext.schema,
+          tableContext.table,
+        );
+        setDDLContent(ddl);
+      } catch (error) {
+        setDDLContent(`-- Error fetching DDL\n-- ${error}`);
+      } finally {
+        setIsLoadingDDL(false);
+      }
+    }
+  };
+
   const resizingRef = useRef<{
     column: string;
     startX: number;
@@ -141,6 +182,17 @@ export function TableView({
             <Button variant="outline" size="sm" className="gap-2">
               <Filter className="w-4 h-4" />
             </Button>
+            {tableContext && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={handleShowDDL}
+                title="View Table Structure (DDL)"
+              >
+                <FileCode className="w-4 h-4" />
+              </Button>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-600">
@@ -261,6 +313,27 @@ export function TableView({
           </Button>
         </div>
       </div>
+      <Dialog open={isDDLModalOpen} onOpenChange={setIsDDLModalOpen}>
+        <DialogContent className="max-w-4xl h-[80vh] flex flex-col p-0 gap-0">
+          <DialogHeader className="px-4 py-3 border-b border-gray-200">
+            <DialogTitle>Table Structure: {tableContext?.table}</DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 min-h-0 relative">
+            <Editor
+              height="100%"
+              defaultLanguage="sql"
+              value={isLoadingDDL ? "-- Loading..." : ddlContent}
+              options={{
+                readOnly: true,
+                minimap: { enabled: false },
+                fontSize: 13,
+                scrollBeyondLastLine: false,
+                automaticLayout: true,
+              }}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -68,6 +68,12 @@ export const api = {
         "get_table_structure",
         { id, schema, table },
       ),
+    getTableDDL: (
+      id: number,
+      database: string | undefined,
+      schema: string,
+      table: string,
+    ) => invoke<string>("get_table_ddl", { id, database, schema, table }),
     listTablesByConn: (form: ConnectionForm) =>
       invoke<{ schema: string; name: string; type: string }[]>(
         "list_tables_by_conn",


### PR DESCRIPTION
为 MySQL 和 PostgreSQL 数据库驱动实现 `get_table_ddl` 方法，用于获取表的创建语句。 在数据表格视图组件中添加“查看DDL”按钮，点击后通过模态框展示格式化后的 SQL 语句。

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new backend command and driver methods that run DDL-introspection SQL against live databases, plus new UI flow; risk is mostly around correctness/edge cases (schemas, quoting) and potential query failures rather than security-critical logic.
> 
> **Overview**
> Adds a new `get_table_ddl` Tauri command and API wrapper to fetch a table’s CREATE statement, including optional database override when resolving a saved connection.
> 
> Extends the `DatabaseDriver` trait and implements `get_table_ddl` for MySQL (`SHOW CREATE TABLE`) and Postgres (builds a `CREATE TABLE` statement from system catalogs).
> 
> Updates the table results UI to pass `tableContext` into `TableView`, show a new “View DDL” button, and display the fetched DDL in a read-only Monaco editor modal (with basic loading/error states).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7939e709dbbc92e3d5b96c8fc93e1ba5a99ca4a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->